### PR TITLE
Long is not a reserved keyword in apex

### DIFF
--- a/src/main/java/Apexcode.g4
+++ b/src/main/java/Apexcode.g4
@@ -734,7 +734,6 @@ IMPORT        : 'import';
 INSTANCEOF    : 'instanceof';
 INT           : 'int';
 INTERFACE     : 'interface';
-LONG          : 'long';
 NATIVE        : 'native';
 NEW           : 'new';
 PACKAGE       : 'package';


### PR DESCRIPTION
Hi, I've noticed that the parser is not able to recognize that this code
```
public class A {
    public Long x;
}
```
is correct. 
I think that the reason is that long is not really a reserved word in apex, even if is marked as such at https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_reserved_words.htm. Actually, Long should be treated in the same manner of String or Blob or Double